### PR TITLE
ci: added conventional commits style check for PR titles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Synfig Studio CI
+name: Build
 
 # Controls when the action will run. 
 on:
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-10.15
+    runs-on: macos-latest
     name: MacOS 10.15 Catalina
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -18,15 +18,14 @@ jobs:
 #      - name: Install gh-cli and npm and conventional commit linter
 #        run: sudo apt install npm gh -y
 
-#      - name: Install conventional commit linter
-#        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
-
-      - uses: actions/checkout@v3
+      - name: Install conventional commit linter
+        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
       - name: Configure commitlint
         run: |
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
+      - uses: actions/checkout@v3
       - name: Lint current pull request title (test)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -25,9 +25,10 @@ jobs:
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
       - name: Lint current pull request title
-        run: jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH" | npx commitlint --verbose
+        run: jq --raw-output ".pull_request.title" "$GITHUB_EVENT_PATH" | npx commitlint --verbose
+
+# The code below is saved for future references.
 #        env:
 #          GH_TOKEN: ${{ github.token }}
 #          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 #          gh pr view $pr_number --json=title --jq '.title' | npx commitlint --verbose
-

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -22,13 +22,14 @@ jobs:
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
       - uses: actions/checkout@v3
-      - name: Lint current pull request title (test)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr view --json=title --jq '.title' | npx commitlint
-
       - name: test
         run: pwd
 
       - name: test2
         run: ls -la
+
+      - name: Lint current pull request title (test)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr view --json=title --jq '.title' | npx commitlint
+

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -21,7 +21,11 @@ jobs:
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
       - name: test
-        run: cat "$GITHUB_EVENT_PATH"
+        run: |
+          echo $MERGE_MESSAGE
+          echo $PR_TITLE
+          echo "==========================="
+          cat "$GITHUB_EVENT_PATH"
 
       - name: Configure commitlint
         run: |

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Configure commitlint
         run: |
-          echo 'module.exports = {extends: ['@commitlint/config-conventional']}' > commitlint.config.js
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
       - name: Lint current pull request title (test)
         env:

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install gh-cli and npm and conventional commit linter
-        run: sudo apt install npm gh -y
+#      - name: Install gh-cli and npm and conventional commit linter
+#        run: sudo apt install npm gh -y
 
-      - name: Install conventional commit linter
-        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
+#      - name: Install conventional commit linter
+#        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
       - uses: actions/checkout@v3
       - name: test

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -18,10 +18,10 @@ jobs:
 #      - name: Install gh-cli and npm and conventional commit linter
 #        run: sudo apt install npm gh -y
 
+      - uses: actions/checkout@v3
+
       - name: Install conventional commit linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
-
-      - uses: actions/checkout@v3
 
       - name: Configure commitlint
         run: |

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -21,11 +21,12 @@ jobs:
       - name: Install conventional commit linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
+      - uses: actions/checkout@v3
+
       - name: Configure commitlint
         run: |
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
-      - uses: actions/checkout@v3
       - name: Lint current pull request title (test)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -22,11 +22,10 @@ jobs:
 #        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
       - uses: actions/checkout@v3
-      - name: test
-        run: pwd
 
-      - name: test2
-        run: ls -la
+      - name: Configure commitlint
+        run: |
+          echo 'module.exports = {extends: ['@commitlint/config-conventional']}' > commitlint.config.js
 
       - name: Lint current pull request title (test)
         env:

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,11 +1,9 @@
 name: Code quality
 
-# update
-
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, edited, synchronize]
     branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,4 +1,4 @@
-name: PR title linter
+name: Code quality
 
 # update
 
@@ -13,6 +13,7 @@ on:
 jobs:
   install-and-lint-pr-title:
     runs-on: ubuntu-latest
+    run-name: Conventional commits linter
 
     steps:
 #      - name: Install gh-cli and npm and conventional commit linter
@@ -32,5 +33,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          gh pr view $pull_number --json=title --jq '.title' | npx commitlint
+          gh pr view $pull_number --json=title --jq '.title' | npx commitlint --verbose
 

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -13,25 +13,22 @@ on:
 jobs:
   install-and-lint-pr-title:
     runs-on: ubuntu-latest
-    name: Conventional commits linter
+    name: Conventional commits style check
 
     steps:
-#      - name: Install gh-cli and npm and conventional commit linter
-#        run: sudo apt install npm gh -y
-
       - uses: actions/checkout@v3
 
-      - name: Install conventional commit linter
+      - name: Install conventional commits linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
       - name: Configure commitlint
         run: |
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
-      - name: Lint current pull request title (test)
+      - name: Lint current pull request title
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          gh pr view $pull_number --json=title --jq '.title' | npx commitlint --verbose
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          gh pr view $pr_number --json=title --jq '.title' | npx commitlint --verbose
 

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,5 +1,7 @@
 name: PR title linter
 
+# update
+
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -5,6 +5,7 @@ name: Code quality
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
+    types: [opened, reopened, edited]
     branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -5,7 +5,7 @@ name: Code quality
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install conventional commits linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
+      - name: test
+        run: cat "$GITHUB_EVENT_PATH"
+
       - name: Configure commitlint
         run: |
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,4 +1,4 @@
-name: Code quality
+name: Style
 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -21,9 +21,7 @@ jobs:
       - name: Install conventional commit linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
-      - name: Checkout (required for PR request)
-        uses: actions/checkout@v3
-
+      - uses: actions/checkout@v3
       - name: Lint current pull request title (test)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -31,5 +31,7 @@ jobs:
       - name: Lint current pull request title (test)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr view --json=title --jq '.title' | npx commitlint
+        run: |
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          gh pr view $pull_number --json=title --jq '.title' | npx commitlint
 

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -20,21 +20,14 @@ jobs:
       - name: Install conventional commits linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
-      - name: test
-        run: |
-          echo $MERGE_MESSAGE
-          echo $PR_TITLE
-          echo "==========================="
-          cat "$GITHUB_EVENT_PATH"
-
       - name: Configure commitlint
         run: |
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
       - name: Lint current pull request title
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          gh pr view $pr_number --json=title --jq '.title' | npx commitlint --verbose
+        run: jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH" | npx commitlint --verbose
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+#          gh pr view $pr_number --json=title --jq '.title' | npx commitlint --verbose
 

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -26,3 +26,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr view --json=title --jq '.title' | npx commitlint
+
+      - name: test
+        run: pwd
+
+      - name: test2
+        run: ls -la

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   install-and-lint-pr-title:
     runs-on: ubuntu-latest
-    run-name: Conventional commits linter
+    name: Conventional commits linter
 
     steps:
 #      - name: Install gh-cli and npm and conventional commit linter


### PR DESCRIPTION
The main feature of these PR is the ability to automatically start the check after editing the title of the PR, so no need to restart this check manually.
This is made possible by the GitHub Actions event system.
In this case, we use the `PR edited` event.

```
  pull_request:
    types: [opened, edited, synchronize]
```

P.S.
PR title is extracted from GitHub Actions JSON file located at ${GITHUB_EVENT_PATH}

> GITHUB_EVENT_PATH
> The path to the file on the runner that contains the full event webhook payload. 
> For example, /github/workflow/event.json.